### PR TITLE
Nightly CI Tests

### DIFF
--- a/.github/workflows/nightly-js-sdk.yaml
+++ b/.github/workflows/nightly-js-sdk.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   run:
-    name: Execute tests
+    name: Execute JS SDK Playwright tests
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
@@ -69,4 +69,3 @@ jobs:
       run: yarn playwright install --with-deps
     - name: Launch E2E tests workflow
       run: yarn test
-    


### PR DESCRIPTION
Add nightly CI execution of Firebse JS SDK tests exercised by Playwright.

The CI workflow caches:
 - yarn install
 - yarn build
 - playwright binaries

The CI workflow will run:
  - Nightly at midnight, PST.
  - on PRs pointing to main.
  - Via manual execution (aka `workflow_dispatch`)

Future configuration within the GitHub repo will email the Firebase JS SDK team if there are failures.