### PR TITLE
feat(deps) Configure dependabot to update package.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Dependabot can notify us of Next.js / Angular updates, instead of running with no-lockfile options in yarn in CI, which could error on any transitive dependency.