### PR TITLE
chore(actions) Update to node v24.0 for send email action

### DIFF
--- a/.github/actions/send-email/action.yml
+++ b/.github/actions/send-email/action.yml
@@ -40,5 +40,5 @@ inputs:
     description: HTML body of the message.
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/js-sdk-framework-tests/nextjs/tsconfig.json
+++ b/js-sdk-framework-tests/nextjs/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
We have an action that sends an email when our nightly tests fail. The action currently runs in node 20.0, which GitHub is deprecating. Updating the GitHub action to 24.0.