### PR TITLE
fix(CI) Next.js Messaging & Firestore Playwright w/ Webkit test failures

### DIFF
--- a/js-sdk-framework-tests/nextjs/src/lib/app_tests/firestore/test.ts
+++ b/js-sdk-framework-tests/nextjs/src/lib/app_tests/firestore/test.ts
@@ -37,7 +37,8 @@ import {
   updateDoc,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   VectorValue,
-  vector
+  vector,
+  initializeFirestore
 } from 'firebase/firestore';
 import { firebaseConfig } from '@/lib/app_tests/firebase';
 import { OK, FAILED, OK_SKIPPED } from '@/lib/app_tests/util';
@@ -221,7 +222,13 @@ export async function testSerializedFirestoreData(
   serializedFirestoreData: SerializedFirestoreData
 ): Promise<TestResults> {
   const firebase = initializeApp(firebaseConfig);
-  const firestore = getFirestore(firebase);
+  const isBrowser = typeof window !== 'undefined';
+  
+  // Playwright's headless WebKit has a bug that causes Firestore getDocs() WebChannel
+  // streams to hang indefinitely. Forcing long polling bypasses the WebSocket issue.
+  const firestore = isBrowser ? initializeFirestore(firebase, {
+    experimentalForceLongPolling: true
+  }) : getFirestore(firebase);
 
   // DocumentSnapshotTests
   if (serializedFirestoreData.documentSnapshotJson != null) {
@@ -356,7 +363,13 @@ export async function testFirestore(isServer: boolean = false): Promise<TestResu
     }
     result.initializeAppResult = OK;
 
-    const firestore = getFirestore(firebaseApp);
+    const isBrowser = typeof window !== 'undefined';
+    
+    // Playwright's headless WebKit has a bug that causes Firestore getDocs() WebChannel
+    // streams to hang indefinitely. Forcing long polling bypasses the WebSocket issue.
+    const firestore = isBrowser ? initializeFirestore(firebaseApp, {
+      experimentalForceLongPolling: true
+    }) : getFirestore(firebaseApp);
     if (firestore === null) {
       return result;
     }

--- a/js-sdk-framework-tests/nextjs/src/lib/app_tests/messaging/test.ts
+++ b/js-sdk-framework-tests/nextjs/src/lib/app_tests/messaging/test.ts
@@ -17,7 +17,7 @@
 
 import { deleteApp, initializeApp } from 'firebase/app';
 import { firebaseConfig } from '@/lib/app_tests/firebase';
-import { getMessaging } from 'firebase/messaging';
+import { getMessaging, isSupported } from 'firebase/messaging';
 import { OK, OK_SKIPPED, FAILED } from '@/lib/app_tests/util';
 
 export type TestResults = {
@@ -50,9 +50,14 @@ export async function testMessaging(isServer: boolean = false): Promise<TestResu
     }
     result.initializeAppResult = OK;
 
-    const messaging = getMessaging(firebaseApp);
-    if (!isServer && messaging || isServer && !messaging) {
-      result.initializeMessagingResult = OK;
+    const supported = await isSupported();
+    if (!supported) {
+      result.initializeMessagingResult = OK_SKIPPED;
+    } else {
+      const messaging = getMessaging(firebaseApp);
+      if (!isServer && messaging || isServer && !messaging) {
+        result.initializeMessagingResult = OK;
+      }
     }
 
     deleteApp(firebaseApp);


### PR DESCRIPTION
 - Firestore: Fixed a timeout issue in the Next.js client-side tests.  `getDocs()` was hanging indefinitely, which seems to be casued in Playwright's newer headless WebKit binary failing to establish WebChannel/WebSocket streams. A peril of updating our dependencies all the time, it seems. I added a workaround to conditionally initialize Firestore with `experimentalForceLongPolling: true` when running in the browser context, which successfully bypasses the WebKit networking bug.

 - Messaging: The test suite now cleanly checks `isSupported()` before attempting to initialize `getMessaging()`, skipping the test gracefully (OK_SKIPPED).
